### PR TITLE
Aggregated Player Career Stats

### DIFF
--- a/collegebaseball/ncaa_scraper.py
+++ b/collegebaseball/ncaa_scraper.py
@@ -169,6 +169,7 @@ def ncaa_career_stats(stats_player_seq, variant, include_advanced=True):
     df['school'] = school
     df['division'] = df['division'].astype('int8')
     df['school'] = df['school'].astype('string')
+    df['season'] = df['season'] + 1
     if variant == 'batting':
         if include_advanced:
             if len(df) > 0:


### PR DESCRIPTION
- create `ncaa_career_aggregated `to pull a player's career stats as a single row. ID columns like `season`, `school_id`, and `division` are left as `0` to main `int` consistency with the original functions. The function is very similar to the original `ncaa_career_stats` function, but tweaked enough that I figured it was easier to have a new function for rather than conditionals

- updated `add_batting_metrics` and `add_pitching_metrics` with a `season = True` default arg to account for generating the career advanced stats. When `season = False`, the function leaves the advanced stats that are dependent on season/team/division as `NA`

- added `df['season'] = df['season'] + 1` for the season-by-season stats from the `ncaa_career_stats` function because it would default `2021-2022` as the `2021` season despite games being played in Spring `2022`