### PR TITLE
Fixed AttributeError caused by incorrect typing 

### DIFF
--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -314,8 +314,8 @@ def add_pitching_metrics(df, season = True):
         df.loc[:, 'wOBA-against'] = np.nan
     df.loc[:, 'WHIP'] = round(
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
-    df.loc[:, 'Pitches/IP'] = round(
-        np.where(df['IP-adj'] != 0, round(df['pitches'] / df['IP-adj'], ROUND_TO), 0))
+    df.loc[:, 'Pitches/IP'] = np.where(df['IP-adj'] != 0, 
+        (df['pitches'] / df['IP-adj']).round(ROUND_TO), 0)
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])
                                      ).replace(np.inf, 0), ROUND_TO)

--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -277,6 +277,7 @@ def add_pitching_metrics(df, season = True):
     Returns:
         DataFrame of stats with additional columns
     """
+    df['pitches'] = df['pitches'].astype(int)
     df['IP-adj'] = df.apply(_adjust_innings_pitched, axis=1)
     df['1B-A'] = df['H']-df['HR-A']-df['3B-A']-df['2B-A']
     df.loc[:, 'OBP-against'] = round((df['H'] + df['BB'] + df['IBB']
@@ -314,10 +315,7 @@ def add_pitching_metrics(df, season = True):
         df.loc[:, 'wOBA-against'] = np.nan
     df.loc[:, 'WHIP'] = round(
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
-    df.loc[:, 'Pitches/IP'] = np.where(
-        df['IP-adj'] != 0,
-        (df['pitches'] / df['IP-adj']).astype(float).apply(lambda x: round(x, ROUND_TO)),
-        0)
+    df.loc[:, 'Pitches/IP'] = (df['pitches'] / (df['IP-adj'])).replace(np.inf, 0).round(ROUND_TO)
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])
                                      ).replace(np.inf, 0), ROUND_TO)

--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -316,7 +316,7 @@ def add_pitching_metrics(df, season = True):
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
     df.loc[:, 'Pitches/IP'] = np.where(
         df['IP-adj'] != 0,
-        (df['pitches'] / df['IP-adj']).round(ROUND_TO),
+        (df['pitches'] / df['IP-adj']).apply(lambda x: round(x, ROUND_TO)),
         0)
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])

--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -316,7 +316,7 @@ def add_pitching_metrics(df, season = True):
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
     df.loc[:, 'Pitches/IP'] = np.where(
         df['IP-adj'] != 0,
-        round(df['pitches'] / df['IP-adj'], ROUND_TO),
+        (df['pitches'] / df['IP-adj']).round(ROUND_TO),
         0)
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])

--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -316,7 +316,7 @@ def add_pitching_metrics(df, season = True):
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
     df.loc[:, 'Pitches/IP'] = np.where(
         df['IP-adj'] != 0,
-        (df['pitches'] / df['IP-adj']).apply(lambda x: round(x, ROUND_TO)),
+        (df['pitches'] / df['IP-adj']).astype(float).apply(lambda x: round(x, ROUND_TO)),
         0)
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])

--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -314,8 +314,10 @@ def add_pitching_metrics(df, season = True):
         df.loc[:, 'wOBA-against'] = np.nan
     df.loc[:, 'WHIP'] = round(
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
-    df.loc[:, 'Pitches/IP'] = np.where(df['IP-adj'] != 0, 
-        (df['pitches'] / df['IP-adj']).round(ROUND_TO), 0)
+    df.loc[:, 'Pitches/IP'] = np.where(
+        df['IP-adj'] != 0,
+        round(df['pitches'] / df['IP-adj'], ROUND_TO),
+        0)
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])
                                      ).replace(np.inf, 0), ROUND_TO)

--- a/collegebaseball/metrics.py
+++ b/collegebaseball/metrics.py
@@ -315,7 +315,7 @@ def add_pitching_metrics(df, season = True):
     df.loc[:, 'WHIP'] = round(
         ((df['H']+df['BB']) / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
     df.loc[:, 'Pitches/IP'] = round(
-        (df['pitches'] / (df['IP-adj'])).replace(np.inf, 0), ROUND_TO)
+        np.where(df['IP-adj'] != 0, round(df['pitches'] / df['IP-adj'], ROUND_TO), 0))
     if 'App' in df.columns:
         df.loc[:, 'IP/App'] = round((df['IP-adj'] / (df['App'])
                                      ).replace(np.inf, 0), ROUND_TO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools ~= 58.0", "wheel", "pandas", "numpy", "requests", "lxml", "bs4", "importlib", "tqdm"]
+requires = ["setuptools ~= 58.0", "wheel", "pandas", "numpy", "requests", "lxml", "bs4", "tqdm"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     long_description=open('DESCRIPTION.rst').read(),
     packages=setuptools.find_packages(),
     install_requires=["pandas", "numpy",
-                      "requests", "lxml", "bs4", "importlib", "tqdm"],
+                      "requests", "lxml", "bs4", "tqdm"],
     keywords=["baseball", "ncaa", "ncaa_baseball",
               "college_baseball", "college_sports"],
     classifiers=[


### PR DESCRIPTION
When calling ncaa_team_stats for pitching, an AttributeError returns because the df['pitches'] columns is of dtype Object when it should be dtype int, so I simply casted it as dtype int