### PR TITLE
Upgrade to run on Python 3.8+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools ~= 58.0", "wheel", "pandas", "numpy", "requests", "lxml", "bs4", "importlib", "tqdm"]
+requires = ["setuptools ~= 58.0", "wheel", "pandas", "numpy", "requests", "lxml", "bs4", "tqdm"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     long_description=open('DESCRIPTION.rst').read(),
     packages=setuptools.find_packages(),
     install_requires=["pandas", "numpy",
-                      "requests", "lxml", "bs4", "importlib", "tqdm"],
+                      "requests", "lxml", "bs4", "tqdm"],
     keywords=["baseball", "ncaa", "ncaa_baseball",
               "college_baseball", "college_sports"],
     classifiers=[


### PR DESCRIPTION
This pull request simplifies the dependency management for the project by removing the `importlib` library from the list of required dependencies in both the `pyproject.toml` and `setup.py` files. This change reflects that `importlib` is part of Python's standard library (Python 3.8+) and does not need to be explicitly listed as a dependency.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R2): Removed `importlib` from the `requires` list under `[build-system]`.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L13-R13): Removed `importlib` from the `install_requires` list.